### PR TITLE
Combat system comands

### DIFF
--- a/src/commands/20th/combat.js
+++ b/src/commands/20th/combat.js
@@ -1,0 +1,106 @@
+"use strict";
+require(`${process.cwd()}/alias`);
+const { SlashCommandBuilder } = require("@discordjs/builders");
+const { update } = require("@modules/tracker");
+const { Splats } = require("@constants");
+const commandUpdate = require("@modules/commandDatabaseUpdate");
+const autocomplete20th = require("@modules/autocomplete");
+const roll20th = require("@modules/dice/roll20th");
+
+module.exports = {
+  data: getCommands(),
+  async execute(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+    await commandUpdate(interaction);
+    if (!interaction.isRepliable()) return "notRepliable";
+    interaction.arguments = await getArgs(interaction);
+    switch (interaction.options.getSubcommand()) {
+      case "attack":
+        return await applyBlood(interaction);
+      //case "gain":
+        //return await update(interaction, Splats.vampire20th);
+      //case "check":
+        //return await update(interaction, Splats.vampire20th);
+    }
+  },
+
+  async autocomplete(interaction) {
+    return await autocomplete20th(interaction, Splats.vampire20th.slug);
+  },
+};
+
+async function applyBlood(interaction) {
+ console.log(interaction);
+ return await update(interaction, Splats.vampire20th);
+
+}
+
+async function getArgs(interaction) {
+    const args = {
+      name: interaction.options.getString("name"),
+      
+      defense_pool: interaction.options.getInteger("defense_pool"),
+      attack_pool_enemy: interaction.options.getInteger("attack_pool_enemy"),
+      damage_pool_weapon: interaction.options.getInteger("damage_pool_weapon"),
+      
+      notes: interaction.options.getString("notes") || "No notes provided"
+    };
+    
+    return args;
+  }
+
+function getCommands() {
+  const slashCommand = new SlashCommandBuilder()
+    .setName("combat")
+    .setDescription("kill the motherfucked");
+
+  /////////////////////// attack combat ////////////////////////////
+
+  slashCommand.addSubcommand((subcommand) =>
+    subcommand
+      .setName("attack")
+      .setDescription("V20 combat system")
+
+      .addStringOption((option) =>
+        option
+          .setName("name")
+          .setDescription("The name of your Character")
+          .setRequired(true)
+          .setMaxLength(50)
+          .setAutocomplete(true)
+      )
+
+      .addIntegerOption(option =>
+        option
+           .setName("defense_pool")
+           .setDescription("Your Defense pool (Dodge/Combat)")
+          .setMinValue(1)
+          .setMaxValue(50)
+          .setRequired(true)
+      )
+
+
+      .addIntegerOption(option =>
+        option
+          .setName("attack_pool_enemy")
+          .setDescription("Attack pool enemy (Skill + Strength)")
+          .setMinValue(1)
+          .setMaxValue(50)
+          .setRequired(true)
+      )
+
+      .addStringOption((option) =>
+        option
+          .setName("damage_pool_weapon")
+          .setDescription("Type Damage pool (Strength + Weapon)")
+          .setRequired(true)
+          .addChoices(
+            { name: "Heal bashing", value: "bashing_damage" },
+            { name: "Heal lethal", value: "lethal_damage" },
+            { name: "Heal aggravated", value: "agg_damage" },
+            { name: "disciplines", value: "use_discipline" }
+          )
+      )
+  );
+  return slashCommand;
+}

--- a/src/commands/20th/combat.js
+++ b/src/commands/20th/combat.js
@@ -13,15 +13,7 @@ module.exports = {
     await interaction.deferReply({ ephemeral: true });
     await commandUpdate(interaction);
     if (!interaction.isRepliable()) return "notRepliable";
-    interaction.arguments = await getArgs(interaction);
-    switch (interaction.options.getSubcommand()) {
-      case "attack":
-        return await applyBlood(interaction);
-      //case "gain":
-        //return await update(interaction, Splats.vampire20th);
-      //case "check":
-        //return await update(interaction, Splats.vampire20th);
-    }
+    return await roll20th(interaction);
   },
 
   async autocomplete(interaction) {
@@ -29,78 +21,50 @@ module.exports = {
   },
 };
 
-async function applyBlood(interaction) {
- console.log(interaction);
- return await update(interaction, Splats.vampire20th);
-
-}
-
-async function getArgs(interaction) {
-    const args = {
-      name: interaction.options.getString("name"),
-      
-      defense_pool: interaction.options.getInteger("defense_pool"),
-      attack_pool_enemy: interaction.options.getInteger("attack_pool_enemy"),
-      damage_pool_weapon: interaction.options.getInteger("damage_pool_weapon"),
-      
-      notes: interaction.options.getString("notes") || "No notes provided"
-    };
-    
-    return args;
-  }
-
 function getCommands() {
-  const slashCommand = new SlashCommandBuilder()
+  return new SlashCommandBuilder()
     .setName("combat")
-    .setDescription("kill the motherfucked");
-
-  /////////////////////// attack combat ////////////////////////////
-
-  slashCommand.addSubcommand((subcommand) =>
-    subcommand
+    .setDescription("V20 Combat System")
+    .addSubcommand(sub => sub
       .setName("attack")
-      .setDescription("V20 combat system")
-
-      .addStringOption((option) =>
-        option
-          .setName("name")
-          .setDescription("The name of your Character")
-          .setRequired(true)
-          .setMaxLength(50)
-          .setAutocomplete(true)
-      )
-
-      .addIntegerOption(option =>
-        option
-           .setName("defense_pool")
-           .setDescription("Your Defense pool (Dodge/Combat)")
-          .setMinValue(1)
-          .setMaxValue(50)
-          .setRequired(true)
-      )
-
-
-      .addIntegerOption(option =>
-        option
-          .setName("attack_pool_enemy")
-          .setDescription("Attack pool enemy (Skill + Strength)")
-          .setMinValue(1)
-          .setMaxValue(50)
-          .setRequired(true)
-      )
-
-      .addStringOption((option) =>
-        option
-          .setName("damage_pool_weapon")
-          .setDescription("Type Damage pool (Strength + Weapon)")
-          .setRequired(true)
-          .addChoices(
-            { name: "Heal bashing", value: "bashing_damage" },
-            { name: "Heal lethal", value: "lethal_damage" },
-            { name: "Heal aggravated", value: "agg_damage" },
-            { name: "disciplines", value: "use_discipline" }
-          )
-      )
-  );
-  return slashCommand;
+      .setDescription("Execute combat action")
+      .addStringOption(opt => opt
+        .setName("name")
+        .setDescription("Attacker's name")
+        .setRequired(true)
+        .setAutocomplete(true))
+      .addIntegerOption(opt => opt
+        .setName("attack_pool")
+        .setDescription("Attack pool (Dexterity + Ability)")
+        .setMinValue(1)
+        .setMaxValue(20)
+        .setRequired(true))
+      .addIntegerOption(opt => opt
+        .setName("defense_pool")
+        .setDescription("Defense pool (Dodge/Combat)")
+        .setMinValue(1)
+        .setMaxValue(20)
+        .setRequired(true))
+      .addIntegerOption(opt => opt
+        .setName("damage_pool")
+        .setDescription("Base damage (Strength + Weapon)")
+        .setMinValue(1)
+        .setMaxValue(10)
+        .setRequired(true))
+      .addStringOption(opt => opt
+        .setName("damage_type")
+        .setDescription("Type of damage inflicted")
+        .setRequired(true)
+        .addChoices(
+          { name: "Bashing", value: "bashing" },
+          { name: "Lethal", value: "lethal" },
+          { name: "Aggravated", value: "aggravated" }
+        ))
+      .addIntegerOption(opt => opt
+        .setName("absorption_pool")
+        .setDescription("Defender's absorption pool")
+        .setMinValue(0)
+        .setMaxValue(10)
+        .setRequired(true))
+    );
 }

--- a/src/modules/combat/20th/CombatHandler20th.js
+++ b/src/modules/combat/20th/CombatHandler20th.js
@@ -1,0 +1,254 @@
+"use strict";
+const { EmbedBuilder } = require("discord.js");
+const { Emoji } = require("@constants");
+const getCharacter = require("@modules/dice/getCharacter");
+const RollResults20th = require("@structures/RollResults20th");
+
+class CombatHandler20th {
+  constructor(interaction) {
+    this.interaction = interaction;
+    this.embeds = [];
+    this.attackRoll = null;
+    this.defenseRoll = null;
+    this.finalDamage = 0;
+  }
+
+  async handleCombat() {
+    const args = await this.getCombatArgs();
+    
+    // 1. Retrieve character data
+    args.attacker = await getCharacter(args.attackerName, this.interaction);
+    args.defender = await getCharacter(args.defenderName, this.interaction);
+
+    // 2. Process Attack Roll
+    await this.processAttack(args);
+    // 3. Process Defense Roll
+    await this.processDefense(args);
+    
+    // Calculate combat outcome
+    const netSuccesses = this.attackRoll.results.total - this.defenseRoll.results.total;
+    
+    if (netSuccesses > 0) {
+      // 5. Calculate and Roll Damage
+      // 6. Calculate and Roll Absorption
+      await this.processDamage(args, netSuccesses);
+      // 7. Apply Final Damage in processDamage      
+      // 8. Create Combat Summary
+      this.createSummaryEmbed(args, netSuccesses);
+    } else {
+      // 9. Defense Success Case
+      this.addDefenseSuccessEmbed();
+    }
+    return { embeds: this.embeds };
+  }
+
+  async processAttack(args) {
+    this.attackRoll = await this.performCombatRoll({
+      ...args,
+      pool: args.attackPool,
+      description: `⚔️ ${args.attacker.name} Attack (${args.attackPool}d10)`
+    });
+    this.embeds.push(this.attackRoll.embed);
+  }
+
+  async processDefense(args) {
+    this.defenseRoll = await this.performCombatRoll({
+      ...args,
+      pool: args.defensePool,
+      description: `🛡️ ${args.defender.name} Defense (${args.defensePool}d10)`
+    });
+    this.embeds.push(this.defenseRoll.embed);
+  }
+
+  async processDamage(args, netSuccesses) {
+    // Calculate and roll damage
+    const damageRoll = await this.rollDamage(args, netSuccesses);
+    
+    // Calculate and roll absorption
+    const absorptionRoll = await this.rollAbsorption(args);
+    
+    // Apply final damage calculations
+    this.applyFinalDamage(args, damageRoll, absorptionRoll);
+  }
+
+  async rollDamage(args, netSuccesses) {
+    const damagePool = args.damagePool + netSuccesses;
+    const damageRoll = await this.performCombatRoll({
+      ...args,
+      pool: damagePool,
+      description: `💥 ${args.damageType.toUpperCase()} Damage (${damagePool}d10)`
+    });
+    this.embeds.push(damageRoll.embed);
+    return damageRoll;
+  }
+
+  async rollAbsorption(args) {
+    const effectiveAbsorption = args.damageType === "aggravated" 
+      ? Math.floor(args.absorptionPool / 2) 
+      : args.absorptionPool;
+    
+    const absorptionRoll = await this.performCombatRoll({
+      ...args,
+      pool: effectiveAbsorption,
+      description: `🛡️ ${args.damageType.toUpperCase()} Absorption (${effectiveAbsorption}d10)`
+    });
+    this.embeds.push(absorptionRoll.embed);
+    return absorptionRoll;
+  }
+
+  applyFinalDamage(args, damageRoll, absorptionRoll) {
+    this.finalDamage = Math.max(0, damageRoll.results.total - absorptionRoll.results.total);
+    
+    if (args.defender?.tracked?.health) {
+      this.applyDamage(args.defender, this.finalDamage, args.damageType);
+      this.embeds.push(this.createHealthEmbed(args.defender));
+    }
+  }
+
+  async getCombatArgs() {
+    return {
+      attackerName: this.interaction.options.getString("name"),
+      defenderName: this.interaction.options.getString("name"),
+      attackPool: this.interaction.options.getInteger("attack_pool"),
+      defensePool: this.interaction.options.getInteger("defense_pool"),
+      damagePool: this.interaction.options.getInteger("damage_pool"),
+      damageType: this.interaction.options.getString("damage_type"),
+      absorptionPool: this.interaction.options.getInteger("absorption_pool"),
+      difficulty: 6,
+    };
+  }
+
+  async performCombatRoll(args) {
+    this.interaction.arguments = args;
+    this.applyDicePenalty();
+    this.interaction.results = new RollResults20th(this.interaction.arguments);
+    
+    return {
+      embed: this.createCombatEmbed(args.description),
+      results: this.interaction.results
+    };
+  }
+
+  createCombatEmbed(title) {
+    const args = this.interaction.arguments;
+    const results = this.interaction.results;
+    
+    const outcomeText = results.total > 0 ? "Success!" : 
+                      results.blackDice.filter(d => d === 1).length > results.total ? 
+                      "Botch!" : "Failure";
+
+    const embed = new EmbedBuilder()
+      .setTitle(title)
+      .setColor(0x8B0000)
+      .addFields(
+        {
+          name: "Dice",
+          value: results.blackDice.map(d => {
+            if (d === 10) return Emoji.green10;
+            return d >= 6 ? Emoji[`green${d}`] : Emoji[`red${d}`];
+          }).join(" "),
+          inline: true
+        },
+        {
+          name: "Successes",
+          value: `${results.total} (Difficulty ${args.difficulty})`,
+          inline: true
+        },
+        {
+          name: "Outcome",
+          value: outcomeText,
+          inline: false
+        }
+      );
+
+    if (args.notes) {
+      embed.addFields({ name: "Notes", value: args.notes, inline: false });
+    }
+
+    return embed;
+  }
+  applyDicePenalty() {
+    if (this.interaction.arguments.character?.tracked?.health) {
+      const healthStatus = this.interaction.arguments.character.tracked.health.damageInfo;
+      const match = healthStatus?.match(/\d+/);
+      const dicePenalty = match ? parseInt(match[0], 10) : 0;
+      
+      this.interaction.arguments.pool = Math.max(
+        1, 
+        this.interaction.arguments.pool - dicePenalty
+      );
+    }
+  }
+  applyDamage(character, amount, type) {
+    if (!character?.tracked?.health) return;
+    
+    const health = character.tracked.health;
+    health.bashing = health.bashing || 0;
+    health.lethal = health.lethal || 0;
+    health.aggravated = health.aggravated || 0;
+    health.max = health.max || 7;
+  
+    switch(type.toLowerCase()) {
+      case "bashing":
+        health.bashing = Math.min(health.bashing + amount, health.max);
+        break;
+      case "lethal":
+        health.lethal = Math.min(
+          health.lethal + amount, 
+          health.max - health.bashing
+        );
+        break;
+      case "aggravated":
+        health.aggravated = Math.min(
+          health.aggravated + amount, 
+          health.max - health.bashing - health.lethal
+        );
+        break;
+    }
+  }
+  createHealthEmbed(character) {
+    const health = character.tracked.health;
+    
+    const bashing = health.bashing || 0;
+    const lethal = health.lethal || 0;
+    const aggravated = health.aggravated || 0;
+  
+    return new EmbedBuilder()
+      .setTitle(`${character.name}'s Health`)
+      .setColor(0x8B0000)
+      .addFields(
+        { name: "Bashing", value: bashing.toString(), inline: true },
+        { name: "Lethal", value: lethal.toString(), inline: true },
+        { name: "Aggravated", value: aggravated.toString(), inline: true }
+      );
+  }
+  createSummaryEmbed(args, netSuccesses) {
+    const summaryEmbed = new EmbedBuilder()
+      .setTitle("🔥 Combat Result")
+      .setColor(this.getDamageColor(args.damageType))
+      .addFields(
+        { name: "Attacker", value: args.attacker.name, inline: true },
+        { name: "Defender", value: args.defender.name, inline: true },
+        { name: "Net Successes", value: netSuccesses.toString(), inline: true },
+        { name: "Damage Type", value: args.damageType.toUpperCase(), inline: true },
+        { name: "Final Damage", value: `${this.finalDamage} ${args.damageType.toUpperCase()}`, inline: false }
+      );
+    
+    this.embeds.push(summaryEmbed);
+  }
+  getDamageColor(type) {
+    const colors = {
+      bashing: 0xFFFF00,
+      lethal: 0xFF0000,
+      aggravated: 0x8B0000
+    };
+    return colors[type.toLowerCase()] || 0x808080;
+  }
+  addDefenseSuccessEmbed() {
+    this.embeds.push(new EmbedBuilder()
+      .setColor(0x00FF00)
+      .setDescription("🎯 Attack was completely defended!")
+    );
+  }
+}
+module.exports = CombatHandler20th;

--- a/src/modules/dice/roll20th.js
+++ b/src/modules/dice/roll20th.js
@@ -115,11 +115,40 @@ async function performCombatRoll(interaction, args) {
 }
 
 function getCombatEmbed(interaction, title) {
-  const embed = getEmbed(interaction);
-  embed.data.title = title;
-  embed.data.fields = embed.data.fields.filter(f => 
-    !["Website", "Commands", "Patreon"].includes(f.name)
-  );
+  const args = interaction.arguments;
+  const results = interaction.results;
+  const outcomeText = results.total > 0 ? "Success!" : 
+                     results.blackDice.filter(d => d === 1).length > results.total ? 
+                     "Botch!" : "Failure";
+
+  const embed = new EmbedBuilder()
+    .setTitle(title)
+    .setColor(0x8B0000)
+    .addFields(
+      {
+        name: "Dice",
+        value: results.blackDice.map(d => {
+          if (d === 10) return Emoji.green10;
+          return d >= 6 ? Emoji[`green${d}`] : Emoji[`red${d}`];
+        }).join(" "),
+        inline: true
+      },
+      {
+        name: "Successes",
+        value: `${results.total} (Difficulty ${args.difficulty})`,
+        inline: true
+      },
+      {
+        name: "Outcome",
+        value: outcomeText,
+        inline: false
+      }
+    );
+
+  if (args.notes) {
+    embed.addFields({ name: "Notes", value: args.notes, inline: false });
+  }
+
   return embed;
 }
 

--- a/src/modules/dice/roll20th.js
+++ b/src/modules/dice/roll20th.js
@@ -8,13 +8,170 @@ const { Emoji } = require("@constants");
 const getCharacter = require("@modules/dice/getCharacter");
 const API = require("@api");
 
+
 module.exports = async function roll20th(interaction) {
+  if (interaction.options.getSubcommand() === "attack") {
+    return handleCombatRoll(interaction);
+  }
+
   interaction.arguments = await getArgs(interaction);
   applyDicePenalty(interaction);
   interaction.results = new RollResults20th(interaction.arguments);
   await updateWillpower(interaction);
   return { content: getContent(interaction), embeds: [getEmbed(interaction)] };
 };
+
+async function handleCombatRoll(interaction) {
+  const args = await getCombatArgs(interaction);
+  const embeds = [];
+  
+
+  // Get character names
+  args.attacker = await getCharacter(args.attacker_name, interaction);
+  args.defender = await getCharacter(args.defender_name, interaction);
+
+  // 1. Attack Roll
+  const attackRoll = await performCombatRoll(interaction, {
+    ...args,
+    pool: args.attack_pool,
+    description: `⚔️ ${args.attacker.name} Attack (${args.attack_pool}d10)`
+  });
+  embeds.push(attackRoll.embed);
+
+  // 2. Defense Roll
+  const defenseRoll = await performCombatRoll(interaction, {
+    ...args,
+    pool: args.defense_pool,
+    description: `🛡️ ${args.defender.name} Defense (${args.defense_pool}d10)`
+  });
+  embeds.push(defenseRoll.embed);
+
+  // 3. Calculate Net Successes
+  const netSuccesses = attackRoll.results.total - defenseRoll.results.total;
+  
+  if (netSuccesses > 0) {
+    // 4. Calculate and Roll Damage
+    const damagePool = args.damage_pool + netSuccesses;
+    const damageRoll = await performCombatRoll(interaction, {
+      ...args,
+      pool: damagePool,
+      description: `💥 ${args.damage_type.toUpperCase()} Damage (${damagePool}d10)`
+    });
+    embeds.push(damageRoll.embed);
+
+    // 5. Calculate and Roll Absorption
+    const effectiveAbsorption = args.damage_type === "aggravated" 
+      ? Math.floor(args.absorption_pool / 2) 
+      : args.absorption_pool;
+    
+    const absorptionRoll = await performCombatRoll(interaction, {
+      ...args,
+      pool: effectiveAbsorption,
+      description: `🛡️ ${args.damage_type.toUpperCase()} Absorption (${effectiveAbsorption}d10)`
+    });
+    embeds.push(absorptionRoll.embed);
+
+    // 6. Calculate Final Damage
+    const finalDamage = Math.max(0, damageRoll.results.total - absorptionRoll.results.total);
+    
+    // 8. Summary Embed
+    if (args.defender?.tracked?.health) {
+      applyDamage(args.defender, finalDamage, args.damage_type);
+      embeds.push(createHealthEmbed(args.defender));
+    }
+
+    // 8. Embed de Resumen
+    const summaryEmbed = new EmbedBuilder()
+      .setTitle("🔥 Combat Result")
+      .setColor(getDamageColor(args.damage_type))
+      .addFields(
+        { name: "Attacker", value: args.attacker.name, inline: true },
+        { name: "Defender", value: args.defender.name, inline: true },
+        { name: "Net Successes", value: netSuccesses.toString(), inline: true },
+        { name: "Damage Type", value: args.damage_type.toUpperCase(), inline: true },
+        { name: "Damage Dealt", value: damageRoll.results.total.toString(), inline: true },
+        { name: "Absorption", value: absorptionRoll.results.total.toString(), inline: true },
+        { name: "Final Damage", value: `${finalDamage} ${args.damage_type.toUpperCase()}`, inline: false }
+      );
+    embeds.push(summaryEmbed);
+  } else {
+    embeds.push(new EmbedBuilder()
+      .setColor(0x00FF00)
+      .setDescription("🎯 Attack was completely defended!"));
+  }
+
+  return { embeds };
+}
+
+async function performCombatRoll(interaction, args) {
+  interaction.arguments = args;
+  applyDicePenalty(interaction);
+  interaction.results = new RollResults20th(interaction.arguments);
+  
+  return {
+    embed: getCombatEmbed(interaction, args.description),
+    results: interaction.results
+  };
+}
+
+function getCombatEmbed(interaction, title) {
+  const embed = getEmbed(interaction);
+  embed.data.title = title;
+  embed.data.fields = embed.data.fields.filter(f => 
+    !["Website", "Commands", "Patreon"].includes(f.name)
+  );
+  return embed;
+}
+
+async function getCombatArgs(interaction) {
+  return {
+    attacker_name: interaction.options.getString("name"),
+    defender_name: interaction.options.getString("name"),
+    attack_pool: interaction.options.getInteger("attack_pool"),
+    defense_pool: interaction.options.getInteger("defense_pool"),
+    damage_pool: interaction.options.getInteger("damage_pool"),
+    damage_type: interaction.options.getString("damage_type"),
+    absorption_pool: interaction.options.getInteger("absorption_pool"),
+    difficulty: 6,
+  };
+}
+
+function applyDamage(character, amount, type) {
+  if (!character?.tracked?.health) return;
+  
+  const health = character.tracked.health;
+  switch(type) {
+    case "bashing":
+      health.bashing = Math.min(health.bashing + amount, health.max);
+      break;
+    case "lethal":
+      health.lethal = Math.min(health.lethal + amount, health.max - health.bashing);
+      break;
+    case "aggravated":
+      health.aggravated = Math.min(health.aggravated + amount, health.max - health.bashing - health.lethal);
+      break;
+  }
+}
+
+function createHealthEmbed(character) {
+  return new EmbedBuilder()
+    .setTitle(`${character.name}'s Health`)
+    .setColor(0x8B0000)
+    .addFields(
+      { name: "Bashing", value: character.tracked.health.bashing.toString(), inline: true },
+      { name: "Lethal", value: character.tracked.health.lethal.toString(), inline: true },
+      { name: "Aggravated", value: character.tracked.health.aggravated.toString(), inline: true }
+    );
+}
+
+function getDamageColor(type) {
+  const colors = {
+    bashing: 0xFFFF00,  // yellow
+    lethal: 0xFF0000,    // red
+    aggravated: 0x8B0000 // red dark
+  };
+  return colors[type] || 0x808080;
+}
 
 async function getArgs(interaction) {
   const args = {


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/95e607d5-bec1-4a3d-b362-d8c73c844ac0)


Added the new combat command in 20TH to perform the rolls pertaining to combat at least in its **generic version**.
What it doesn't do:

>**Update the player for damage received.**
>**Use disciplines like power/strength for automatic successes**

What it does do:

**>Initial attacking roll
>Defence roll (eliminates success on attack roll)
>Weapon damage roll+succeed on initial attack roll
>Damage absorption roll (each success reduces weapon damage)
>Summary with damage taken**

_Attached image of how the rolls would look like:_

When the attacker or defender cancels all of the attacker's successes (Umm maybe it would be better to just the initial attack and defence roll and then show the summary of the damage received so it doesn't take up too much discord space).

![image](https://github.com/user-attachments/assets/d8930d37-448d-4f07-9151-77fa5ec36214)

When the attacker is more successful than the defender. Roll damage and absorption.

![image](https://github.com/user-attachments/assets/0c8b53b3-eb68-4356-8f0c-45335f3ab185)

![image](https://github.com/user-attachments/assets/c5085796-39ea-434e-9316-4969560ea69f)

